### PR TITLE
Fix #26 Add proxy selector

### DIFF
--- a/backend/src/main/java/org/seedstack/hub/application/ConfigurationException.java
+++ b/backend/src/main/java/org/seedstack/hub/application/ConfigurationException.java
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2015-2016, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.hub.application;
+
+public class ConfigurationException extends RuntimeException {
+
+    public ConfigurationException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/org/seedstack/hub/infra/vcs/ProxySelectorService.java
+++ b/backend/src/main/java/org/seedstack/hub/infra/vcs/ProxySelectorService.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2015-2016, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.hub.infra.vcs;
+
+import com.google.common.collect.Lists;
+import org.apache.commons.configuration.Configuration;
+import org.seedstack.hub.application.ConfigurationException;
+import org.seedstack.seed.Application;
+import org.seedstack.seed.LifecycleListener;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.net.*;
+import java.util.*;
+
+public class ProxySelectorService extends ProxySelector implements LifecycleListener {
+
+    public static final String PROXY = "proxy";
+    public static final String PORT = "port";
+    public static final String HOST = "host";
+    public static final String TYPE = "type";
+    public static final String EXCLUDE = "exclude";
+    private ProxySelector defaultProxySelector;
+    private Optional<Proxy> proxy = Optional.empty();
+    private Optional<String> exclude = Optional.empty();
+
+    @Inject
+    private Application application;
+
+    @Override
+    public List<Proxy> select(URI uri) {
+        if (uri == null) {
+            throw new IllegalArgumentException("URI can't be null.");
+        }
+        String protocol = uri.getScheme();
+        if (("http".equalsIgnoreCase(protocol) || "https".equalsIgnoreCase(protocol)) && isNotExcluded(uri)) {
+            return Lists.newArrayList(proxy.orElse(Proxy.NO_PROXY));
+        }
+        if (defaultProxySelector != null) {
+            return defaultProxySelector.select(uri);
+        } else {
+            ArrayList<Proxy> l = new ArrayList<>();
+            l.add(Proxy.NO_PROXY);
+            return l;
+        }
+    }
+
+    private boolean isNotExcluded(URI uri) {
+        return !exclude.isPresent() || !uri.getHost().contains(exclude.get());
+    }
+
+    @Override
+    public void connectFailed(URI uri, SocketAddress sa, IOException ioe) {
+        // nothing to do
+    }
+
+    @Override
+    public void start() {
+        defaultProxySelector = ProxySelector.getDefault();
+        initializeProxiesFromConfiguration();
+        ProxySelector.setDefault(this);
+    }
+
+    private void initializeProxiesFromConfiguration() {
+        Configuration proxyConfig = application.getConfiguration().subset(PROXY);
+
+        if (!proxyConfig.isEmpty()) {
+            if (!proxyConfig.containsKey(TYPE)) {
+                throw new ConfigurationException("Missing \"type\"  in the proxy configuration.");
+            }
+            String type = proxyConfig.getString(TYPE);
+
+            if (!proxyConfig.containsKey(HOST)) {
+                throw new ConfigurationException("Missing \"url\" in the proxy configuration.");
+            }
+            String url = proxyConfig.getString(HOST);
+
+            if (!proxyConfig.containsKey(PORT)) {
+                throw new ConfigurationException("Missing \"port\"  in the proxy configuration.");
+            }
+            int port = proxyConfig.getInt(PORT);
+
+            exclude = Optional.ofNullable(proxyConfig.getString(EXCLUDE, null));
+            proxy = Optional.of(new Proxy(Proxy.Type.valueOf(type), new InetSocketAddress(url, port)));
+        } else {
+            proxy = Optional.empty();
+            exclude = Optional.empty();
+        }
+    }
+
+    @Override
+    public void stop() {
+        ProxySelector.setDefault(null);
+    }
+}

--- a/backend/src/main/resources/META-INF/configuration/seedstack-hub.props
+++ b/backend/src/main/resources/META-INF/configuration/seedstack-hub.props
@@ -21,3 +21,9 @@ databases = hub
 [org.seedstack.hub.domain.model.*]
 morphia.clientName = main
 morphia.dbName = hub
+
+# [proxy]
+# type=HTTP
+# host=proxy.mycompany.com
+# port=8080
+# exclude=.mycompany.com

--- a/backend/src/test/java/org/seedstack/hub/infra/vcs/ProxySelectorServiceTest.java
+++ b/backend/src/test/java/org/seedstack/hub/infra/vcs/ProxySelectorServiceTest.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) 2015-2016, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.hub.infra.vcs;
+
+import mockit.*;
+import mockit.integration.junit4.JMockit;
+import org.apache.commons.configuration.Configuration;
+import org.assertj.core.api.Assertions;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.seedstack.hub.application.ConfigurationException;
+import org.seedstack.seed.Application;
+
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.URI;
+import java.util.List;
+
+@RunWith(JMockit.class)
+public class ProxySelectorServiceTest {
+
+    @Tested
+    private ProxySelectorService underTest;
+    @Injectable
+    private Application application;
+    @Mocked
+    private Configuration configuration;
+
+    @After
+    public void tearDown() throws Exception {
+        if (underTest != null) {
+            underTest.stop();
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBadUri() throws Exception {
+        underTest.select(null);
+    }
+
+    @Test
+    public void testWithNoProxy() throws Exception {
+        givenProxy(null, null, null, null);
+        underTest.start();
+        List<Proxy> select = underTest.select(new URI("http://localhost:42"));
+        underTest.stop();
+        assertNoProxy(select);
+    }
+
+    @Test
+    public void testWithNoProxyDefault() throws Exception {
+        List<Proxy> select = underTest.select(new URI("http://localhost:42"));
+        assertNoProxy(select);
+    }
+
+    @Test
+    public void testConfigurationError() throws Exception {
+        givenProxy("HTTP", null, 8080, null);
+        try {
+            underTest.start();
+            Assertions.failBecauseExceptionWasNotThrown(ConfigurationException.class);
+        } catch (ConfigurationException e) {
+            Assertions.assertThat(e).hasMessage("Missing \"url\" in the proxy configuration.");
+        }
+    }
+
+    @Test
+    public void testWithProxy() throws Exception {
+        givenProxy("HTTP", "proxy.mycompany.com", 8080, null);
+        underTest.start();
+        List<Proxy> select = underTest.select(new URI("http://localhost"));
+        underTest.stop();
+        assertProxy(select, Proxy.Type.HTTP, "proxy.mycompany.com", 8080);
+    }
+
+    @Test
+    public void testProxyWithExclusion() throws Exception {
+        givenProxy("HTTP", "proxy.mycompany.com", 8080, "mycompany.com");
+        underTest.start();
+        List<Proxy> select = underTest.select(new URI("http://app.mycompany.com"));
+        underTest.stop();
+        assertNoProxy(select);
+    }
+
+    @Test
+    public void testProxyWithExclusionNoMatch() throws Exception {
+        givenProxy("HTTP", "proxy.mycompany.com", 8080, "mycompany.com");
+        underTest.start();
+        List<Proxy> select = underTest.select(new URI("http://localhost"));
+        underTest.stop();
+        assertProxy(select, Proxy.Type.HTTP, "proxy.mycompany.com", 8080);
+    }
+
+    private void assertNoProxy(List<Proxy> select) {
+        Assertions.assertThat(select).containsExactly(Proxy.NO_PROXY);
+    }
+
+    private void assertProxy(List<Proxy> select, Proxy.Type type, String host, int port) {
+        Assertions.assertThat(select).hasSize(1);
+        Assertions.assertThat(select.get(0).type()).isEqualTo(type);
+        Assertions.assertThat(((InetSocketAddress) select.get(0).address()).getHostName()).isEqualTo(host);
+        Assertions.assertThat(((InetSocketAddress) select.get(0).address()).getPort()).isEqualTo(port);
+    }
+
+    private void givenProxy(String type, String host, Integer port, String exclude) {
+        new NonStrictExpectations() {{
+            application.getConfiguration(); result = configuration;
+
+            configuration.isEmpty(); result = type == null && host == null && port == null;
+
+            configuration.containsKey("type"); result = type != null;
+            configuration.getString("type"); result = type;
+
+            configuration.containsKey("host"); result = host != null;
+            configuration.getString("host"); result = host;
+
+            configuration.containsKey("port"); result = port != null;
+            configuration.getInt("port"); result = port;
+
+            configuration.getString("exclude", null); result = exclude != null ? ".mycompany.com" : null;
+        }};
+    }
+}


### PR DESCRIPTION
This PR add the possibility to configure a proxy for HTTP and HTTPS requests. It possible to exclude some requests using an exclude pattern. The exclusion is implemented with the `String`'s `contains(String)` method.

```
[proxy]
type=HTTP
host=proxy.mycompany.com
port=8080
exclude=.mycompany.com
```

Fixes #26 